### PR TITLE
improve: bold-style for typename

### DIFF
--- a/src/assert-diff/printer.cr
+++ b/src/assert-diff/printer.cr
@@ -49,12 +49,12 @@ module AssertDiff
                   diff.keys.sort!.join("\n") { |k| dump(diff[k], k, indent) + "," }
                 end
       prefix = key ? "#{indent}#{key}: " : indent
-      prefix += "#{typename} " if typename
+      prefix += "#{typename.colorize.mode(:bold)} " if typename
 
       <<-HASH
-      #{prefix}{
+      #{prefix}#{"{".colorize(:dark_gray)}
       #{content}
-      #{indent}}
+      #{indent}#{"}"}
       HASH
     end
 


### PR DESCRIPTION
Maybe easy to read a bit.
![image](https://user-images.githubusercontent.com/2990285/115385321-fa74c600-a212-11eb-8978-29c0cf6ebb62.png)
